### PR TITLE
Leaderboard Route

### DIFF
--- a/server/pkg/routes/handlers.go
+++ b/server/pkg/routes/handlers.go
@@ -73,7 +73,7 @@ func GetQuestionHandler(w http.ResponseWriter, r *http.Request) {
 	serveJSON(w, http.StatusOK, response)
 }
 
-func ServeLeaderboardHandler(w http.ResponseWriter, r *http.Request){
+func ServeLeaderboardHandler(w http.ResponseWriter, r *http.Request) {
 
-	serveJSON(w,http.StatusOK, db.Leaderboard)
+	serveJSON(w, http.StatusOK, db.Leaderboard)
 }

--- a/server/pkg/routes/helpers.go
+++ b/server/pkg/routes/helpers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -82,6 +83,7 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) err
 func serveJSON(w http.ResponseWriter, status int, class interface{}) {
 	jsonToServe, err := json.Marshal(class)
 	if err != nil {
+		log.Println(err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/pkg/routes/routes.go
+++ b/server/pkg/routes/routes.go
@@ -22,7 +22,7 @@ func Init() chi.Router {
 		r.Post("/get-question", GetQuestionHandler)
 	})
 
-	r.Get("/leaderboard",ServeLeaderboardHandler)
-	
+	r.Get("/leaderboard", ServeLeaderboardHandler)
+
 	return r
 }


### PR DESCRIPTION
Add a Route for Leaderboard. Handle GET requests from the user to serve him the leaderboard in the form of  JSON.

Also, the helper ServeJSON should simply return incase there is an error is encoding into JSON and should not write a malformed JSON.