### PR TITLE
Add Leaderboard Interface

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,8 @@ import { ThemeProvider, CSSReset, DarkMode } from "@chakra-ui/core";
 import Portal from "./Components/Portal/Portal";
 import Login from "./Components/LoginAndRegistration/Login";
 import Register from "./Components/LoginAndRegistration/Register";
+import Leaderboard from "./Components/Leaderboard/Leaderboard"
+import Team from "./Components/Team/Team";
 import LandingPage from "./Components/LandingPage/Landing";
 import customTheme from "./theme";
 
@@ -23,9 +25,15 @@ function App() {
             <Route path="/register">
               <Register />
             </Route>
+            <Route path="/team">
+              <Team />
+            </Route>
+            <Route path="/leaderboard">
+             <Leaderboard />
+            </Route>
             <Route path="/">
               <LandingPage />
-            </Route>
+            </Route>           
           </Switch>
         </Router>
       </DarkMode>

--- a/client/src/Components/Leaderboard/Leaderboard.js
+++ b/client/src/Components/Leaderboard/Leaderboard.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { FaAngleLeft, FaAngleRight, FaSearch } from "react-icons/fa";
+import {
+  Flex,
+  Box,
+  Divider,
+  Input,
+  FormControl,
+  IconButton,
+  Heading,
+} from "@chakra-ui/core";
+import Navbar from "../Navbar/Navbar";
+import Table from "./table";
+import "./styles.css";
+// import { icons } from "react-icons/lib/cjs";
+
+function Leaderboard() {
+  return (
+    <Box className="page">
+      <Navbar />
+      <Flex
+        align="center"
+        justify="space-between"
+        flexDirection="column"
+        className="leaderboard"
+      >
+        <Heading
+          marginTop="1.5rem"
+          letterSpacing={[3, 7, 8]}
+          fontWeight={[520, 600, 600]}
+          marginRight={["-3", "-7", "-8"]}
+          className="heading"
+        >
+          LEADERBOARD
+          <Divider />
+        </Heading>
+        <Flex className="filters">
+          <FormControl>
+            <Input placeholder="Team/User Name" size="sm" />
+          </FormControl>
+          <IconButton
+            aria-label="Search"
+            icon={FaSearch}
+            size="sm"
+            className="search"
+          />
+        </Flex>
+        <Table />
+        <Box className="paginator">
+          <IconButton icon={FaAngleLeft} size="sm" />
+          &nbsp;Page 1 of 20&nbsp;
+          <IconButton icon={FaAngleRight} size="sm" />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}
+
+export default Leaderboard;

--- a/client/src/Components/Leaderboard/styles.css
+++ b/client/src/Components/Leaderboard/styles.css
@@ -1,0 +1,82 @@
+.leaderboard {
+  max-width: 70%;
+  margin-top: 2rem;
+  margin: auto;
+}
+table.table {
+  margin: 1rem;
+  padding: 2rem;
+  width: 100%;
+  max-width: 100%;
+  border-width: 5px;
+  border-color: #1a202c;
+}
+
+table.table > tr {
+  border-color: #212837;
+  border-left: 2px;
+  border-right: 2px;
+}
+
+.heading {
+  text-transform: uppercase;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  letter-spacing: 8px;
+  margin-right: -8px;
+}
+.table th {
+  padding-top: 0rem;
+  padding-bottom: 0.75rem;
+  text-align: center;
+  font-weight: 580;
+  border-bottom: 2px solid #9ae6b4;
+}
+
+.table td {
+  text-align: center;
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+}
+tr:nth-child(even) {
+  background-color: #212837;
+}
+
+tr:nth-child(odd) {
+  background-color: #1a202c;
+}
+.filters {
+  margin-top: 1rem;
+  align-self: flex-end;
+}
+.paginator {
+  align-self: flex-end;
+}
+
+@media screen and (max-width: 480px) {
+  .filters {
+    align-self: auto;
+  }
+  .paginator {
+    align-self: auto;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .heading-text {
+    font-weight: 600;
+    letter-spacing: 7px;
+  }
+}
+
+@media screen and (max-width: 360px) {
+  .heading {
+    font-weight: 550;
+    letter-spacing: 3px;
+  }
+}
+
+.search {
+  margin-left: 8px;
+}

--- a/client/src/Components/Leaderboard/table.js
+++ b/client/src/Components/Leaderboard/table.js
@@ -1,0 +1,97 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Text, Collapse, Button } from "@chakra-ui/core";
+import "./styles.css";
+
+function Record(props) {
+  const [show, setShow] = React.useState(false);
+  const handleToggle = () => setShow(!show);
+  const { users, rank, team } = props;
+  const members = users.map((user) => <Text>{user}</Text>);
+  return (
+    <tr className="record">
+      <td>{rank}</td>
+      <td>
+        <Collapse isOpen={show} startingHeight={25}>
+          <Button variant="link" onClick={handleToggle} marginBottom="8px" marginTop="2px">
+            {team}
+          </Button>
+          {members}
+        </Collapse>
+      </td>
+      <td>20</td>
+    </tr>
+  );
+}
+
+Record.propTypes = {
+  users: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rank: PropTypes.number.isRequired,
+  team: PropTypes.string.isRequired,
+};
+
+function Table() {
+  return (
+    <table className="table">
+      <tr>
+        <th>Rank</th>
+        <th>Team</th>
+        <th>Level</th>
+      </tr>
+      <tbody>
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+        <Record
+          rank="2"
+          team="adaephonben"
+          users={["RonaldRoe", "JaneDoe", "RonaldRoe", "JaneDoe"]}
+        />
+      </tbody>
+    </table>
+  );
+}
+
+export default Table;

--- a/client/src/Components/Navbar/Navbar.js
+++ b/client/src/Components/Navbar/Navbar.js
@@ -1,4 +1,5 @@
-import React, { ReactPropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { Box, Heading, Flex, Text, Link } from "@chakra-ui/core";
 import "./styles.css";
 
@@ -9,7 +10,7 @@ const MenuItems = ({ children }) => (
 );
 
 MenuItems.propTypes = {
-  children: ReactPropTypes.string,
+  children: PropTypes.string,
 };
 
 MenuItems.defaultProps = {
@@ -67,12 +68,12 @@ export default class Navbar extends React.Component {
           justifyContent="right"
         >
           <MenuItems>
-            <Link href="google.com" isExternal className="navbar-link">
+            <Link href="https://discord.gg" isExternal className="navbar-link">
               Forum
             </Link>
           </MenuItems>
           <MenuItems>
-            <Link href="google.com" className="navbar-link">
+            <Link href="/leaderboard" className="navbar-link">
               Leaderboard
             </Link>
           </MenuItems>
@@ -87,7 +88,7 @@ export default class Navbar extends React.Component {
             </Link>
           </MenuItems>
           <MenuItems>
-            <Link href="google.com" className="navbar-link">
+            <Link href="https://google.com" className="navbar-link">
               Sign Out
             </Link>
           </MenuItems>

--- a/client/src/Components/Team/Team.js
+++ b/client/src/Components/Team/Team.js
@@ -1,0 +1,86 @@
+import React from "react";
+import "./styles.css";
+import {
+    Flex,
+    Box,
+    Heading,
+    Avatar,
+    Progress,
+    Divider,
+} from "@chakra-ui/core"
+import Navbar from "../Navbar/Navbar";
+
+function Team () {
+    return (
+        <section>
+        <Navbar/>
+        <Flex className="body" flexDirection="column">
+        <Flex flexDirection="row" className="about">
+        <Avatar name="Lambda IITH" size="lg"/>
+        <Box>
+            <p>
+            &nbsp;Lambda IIT H
+            </p>
+            <Divider/>
+            &nbsp;Password:Blahblah
+        </Box>
+        </Flex>
+        <Heading size="md" className="dividingHeader">Progress</Heading>
+        <Divider/>
+            <Flex className="progress">
+                <Box>
+                    Track 1
+                    <Progress value={50}/>
+                </Box>
+                <Box>
+                    Track 2
+                    <Progress value={70}/>
+                </Box>
+                <Box>
+                    Track 3
+                <Progress value={60}/>
+                </Box>
+                <Box>
+                    Track 4
+                <Progress value={80}/>
+                </Box>
+            </Flex>
+            <Heading size="md" className="dividingHeader">
+                Team Members
+            </Heading>
+            <Divider/>
+        <Flex className="members">
+            <table className="table">
+                <tr>
+                    <th>Name</th>
+                    <th>UserName</th>
+                    <th>Questions Solved</th>
+                </tr>
+                <tr>
+                    <td>Vishnu VS</td>
+                    <td>adaephonben</td>
+                    <td>20</td>
+                </tr>
+                <tr>
+                    <td>Ronald Roe</td>
+                    <td>chilledMustang</td>
+                    <td>5</td>
+                </tr>
+                <tr>
+                    <td>Nikhil Reddy</td>
+                    <td>npalladium</td>
+                    <td>20</td>
+                </tr>
+                <tr>
+                    <td>Tanmay Renugunta</td>
+                    <td>StrangeAmeoba</td>
+                    <td>20</td>
+                </tr>
+            </table>
+        </Flex>
+        </Flex>
+        </section>
+    )
+}
+
+    export default Team;

--- a/client/src/Components/Team/styles.css
+++ b/client/src/Components/Team/styles.css
@@ -1,0 +1,36 @@
+.body {
+    margin:auto;
+    padding: auto;
+    width:80%;
+}
+.progress{
+    flex-wrap: wrap;
+    flex:4;
+}
+
+.progress > * {
+    padding: 2rem;
+    width: 20%;
+}
+.about {
+    padding: 2rem;
+}
+.table{
+    margin:1rem;
+    padding:2rem;
+    width: 80%;
+    max-width: 100%;
+    align-self: center;
+}
+.table th {
+    padding-top: 0rem;
+    padding-bottom: 0.75rem;
+	text-align:center;
+	font-weight: 600;
+	border-bottom: 2px solid #9ae6b4;
+} 
+
+.dividingHeader {
+    align-self: flex-start;
+    padding-left: 10px;
+}


### PR DESCRIPTION
- Add Leaderboard Front-End Interface.(complete)
- Add a basic Team Page (usable on desktop,still needs some work)
- Fix Prop-Types bug in ` client/src/Components/Navbar' `(fix was committed to the wrong branch, by @AdaephonBen )
- Add New Routes for Team and Leaderboard
- `npm run lint ` runs successfully

